### PR TITLE
XiaomiDoze, XiaomiParts: Fix mismatch in the <uses-library>

### DIFF
--- a/doze/Android.mk
+++ b/doze/Android.mk
@@ -14,6 +14,10 @@ LOCAL_PRIVATE_PLATFORM_APIS := true
 
 LOCAL_USE_AAPT2 := true
 
+LOCAL_OPTIONAL_USES_LIBRARIES := \
+    androidx.window.extensions \
+    androidx.window.sidecar
+
 LOCAL_STATIC_ANDROID_LIBRARIES := \
     SettingsLib
 

--- a/parts/Android.mk
+++ b/parts/Android.mk
@@ -19,6 +19,10 @@ LOCAL_PRIVILEGED_MODULE := true
 
 LOCAL_USE_AAPT2 := true
 
+LOCAL_OPTIONAL_USES_LIBRARIES := \
+    androidx.window.extensions \
+    androidx.window.sidecar
+
 LOCAL_STATIC_ANDROID_LIBRARIES := \
     SettingsLib
 


### PR DESCRIPTION
error: mismatch in the <uses-library> tags between the build system and the manifest:
	- required libraries in build system: [] vs. in the manifest: []
	- optional libraries in build system: [] vs. in the manifest: [androidx.window.extensions, androidx.window.sidecar]
	- tags in the manifest (out/target/common/obj/APPS/XiaomiDoze_intermediates/manifest/AndroidManifest.xml): <uses-library android:name="androidx.window.extensions" android:required="false"/> <uses-library android:name="androidx.window.sidecar" android:required="false"/>